### PR TITLE
Notify users of open V1/V2 positions

### DIFF
--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -2,6 +2,8 @@
 	import Wallet from '../Wallet.svelte'
 
 	import { currentPage } from '../../lib/stores'
+	import { showModal } from '../../lib/utils'
+	import { legacyPositions } from '../../lib/legacy'
 </script>
 
 <style>
@@ -20,9 +22,13 @@
 		align-items: center;
 	}
 
-	.left a {
+	.left a, .left span {
 		color: var(--sonic-silver);
 		margin-right: var(--base-padding);
+	}
+
+	.clickable {
+		cursor: pointer;
 	}
 
 	.left a.active {
@@ -53,6 +59,11 @@
 		<a class:active={$currentPage == 'trade'} href='#/trade'>Trade</a>
 		<a class:active={$currentPage == 'pool'} href='#/pool'>Pool</a>
 		<a href='https://docs.cap.finance' target='_blank'>Docs</a>
+		{#if $legacyPositions && $legacyPositions.length}
+			<span class='clickable' on:click={() => showModal('LegacyPositions', $legacyPositions)} data-intercept="true">
+				Legacy Positions
+			</span>
+		{/if}
 	</div>
 
 	<div class='right'>

--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -22,13 +22,9 @@
 		align-items: center;
 	}
 
-	.left a, .left span {
+	.left a, .headerBtn {
 		color: var(--sonic-silver);
 		margin-right: var(--base-padding);
-	}
-
-	.clickable {
-		cursor: pointer;
 	}
 
 	.left a.active {
@@ -47,6 +43,12 @@
 		opacity: 1;
 	}
 
+	.headerBtn {
+		background: none;
+		padding: 0;
+
+	}
+
 </style>
 
 
@@ -60,9 +62,9 @@
 		<a class:active={$currentPage == 'pool'} href='#/pool'>Pool</a>
 		<a href='https://docs.cap.finance' target='_blank'>Docs</a>
 		{#if $legacyPositions && $legacyPositions.length}
-			<span class='clickable' on:click={() => showModal('LegacyPositions', $legacyPositions)} data-intercept="true">
+			<button class='headerBtn' on:click={() => showModal('LegacyPositions', $legacyPositions)} data-intercept="true">
 				Legacy Positions
-			</span>
+			</button>
 		{/if}
 	</div>
 

--- a/src/components/layout/Modals.svelte
+++ b/src/components/layout/Modals.svelte
@@ -12,6 +12,7 @@
 	import PoolDeposit from '../modals/PoolDeposit.svelte'
 	import PoolWithdraw from '../modals/PoolWithdraw.svelte'
 	
+	import LegacyPositions from '../modals/LegacyPositions.svelte'
 </script>
 
 {#if $activeModal && $activeModal.name == 'Connect'}
@@ -20,6 +21,10 @@
 
 {#if $activeModal && $activeModal.name == 'Products'}
 <Products />
+{/if}
+
+{#if $activeModal && $activeModal.name == 'LegacyPositions'}
+<LegacyPositions data={$activeModal.data} />
 {/if}
 
 <TradeDetails isActive={$activeModal && $activeModal.name == 'TradeDetails'}  data={$activeModal.data} />

--- a/src/components/modals/LegacyPositions.svelte
+++ b/src/components/modals/LegacyPositions.svelte
@@ -1,0 +1,34 @@
+<script>
+	import Modal from './Modal.svelte'
+
+	export let data;
+</script>
+
+<style>
+	div {
+		width: 90%;
+		margin: 10px auto;
+	}
+	p {
+		line-height: 1.618;
+	}
+
+	ul {
+		margin: 0 auto;
+	}
+	li {
+		line-height: 1.618;
+		padding: 10px 0;
+	}
+</style>
+
+<Modal>
+	<div>
+		<p>You also have open positions against previous versions of the Cap protocol that will not show up in this version. To view them, follow the links below:</p>
+		<ul>
+			{#each data as d}
+				<li>{d.message}<br /><a href={d.href} target="_blank">{d.href}</a></li>
+			{/each}
+		</ul>
+	</div>
+</Modal>

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -96,3 +96,8 @@ export const CHAINDATA = {
 		cap: '0x031d35296154279DC1984dCD93E392b1f946737b'
 	}
 }
+
+// Whether we should check for outstanding
+// positions/stakes in previous versions
+export const CHECK_V1_POSITIONS = true;
+export const CHECK_V2_POSITIONS = true;

--- a/src/lib/legacy.js
+++ b/src/lib/legacy.js
@@ -1,0 +1,31 @@
+import { derived } from 'svelte/store'
+
+import { v1PositionIDs, v1StakeIDs } from './v1/stores';
+import { v2PositionIDs } from './v2/stores';
+
+export const legacyPositions = derived([v1PositionIDs, v1StakeIDs, v2PositionIDs], async ([$v1PositionIDs, $v1StakeIDs, $v2PositionIDs], set) => {
+	const results = [];
+
+	if ($v1PositionIDs.length) {
+		results.push({
+			message: 'Open V1 positions:',
+			href: 'https://v1.cap.finance/#/trade',
+		});
+	}
+
+	if ($v1StakeIDs.length) {
+		results.push({
+			message: 'Staked V1 ETH:',
+			href: 'https://v1.cap.finance/#/vault',
+		});
+	}
+
+	if ($v2PositionIDs.length) {
+		results.push({
+			message: 'Open V2 positions:',
+			href: 'https://v2.cap.finance/#/trade',
+		});
+	}
+
+	set(results);
+});

--- a/src/lib/v1/graph.js
+++ b/src/lib/v1/graph.js
@@ -1,0 +1,45 @@
+const graph_url = 'https://api.thegraph.com/subgraphs/name/0xcap/capv1';
+
+export async function getV1PositionIDs(owner) {
+	if (!owner) return;
+	const response = await fetch(graph_url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			query: `
+				query {
+					positions(where: {owner: "${owner}"}) {
+						id
+					}
+				}
+			`
+		})
+	});
+	const json = await response.json();
+	let ids = json.data.positions.map((x) => {return x.id});
+	return ids;
+}
+
+export async function getV1StakeIDs(owner) {
+	if (!owner) return;
+	const response = await fetch(graph_url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			query: `
+				query {
+					stakes(where: {owner: "${owner}"}) {
+						id
+					}
+				}
+			`
+		})
+	});
+	const json = await response.json();
+	let ids = json.data.stakes.map((x) => {return x.id});
+	return ids;
+}

--- a/src/lib/v1/stores.js
+++ b/src/lib/v1/stores.js
@@ -1,0 +1,24 @@
+import { derived } from 'svelte/store'
+
+import { getV1PositionIDs, getV1StakeIDs } from './graph'
+
+import { CHECK_V1_POSITIONS } from '../constants';
+import { address } from '../stores';
+
+export const v1PositionIDs = derived(address, async ($address, set) => {
+	if (!CHECK_V1_POSITIONS || !$address) {
+		set([]);
+		return;
+	}
+
+	set(await getV1PositionIDs($address));
+},[]);
+
+export const v1StakeIDs = derived(address, async ($address, set) => {
+	if (!CHECK_V1_POSITIONS || !$address) {
+		set([]);
+		return;
+	}
+
+	set(await getV1StakeIDs($address));
+},[]);

--- a/src/lib/v2/graph.js
+++ b/src/lib/v2/graph.js
@@ -1,0 +1,23 @@
+const graph_url = 'https://api.thegraph.com/subgraphs/name/0xcap/cap2';
+
+export async function getV2PositionIDs(owner) {
+	if (!owner) return;
+	const response = await fetch(graph_url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			query: `
+				query {
+					positions(where: {owner: "${owner}"}) {
+						id
+					}
+				}
+			`
+		})
+	});
+	const json = await response.json();
+	let ids = json.data.positions.map((x) => {return x.id});
+	return ids;
+}

--- a/src/lib/v2/stores.js
+++ b/src/lib/v2/stores.js
@@ -1,0 +1,15 @@
+import { derived } from 'svelte/store'
+
+import { getV2PositionIDs } from './graph'
+
+import { CHECK_V2_POSITIONS } from '../constants';
+import { address } from '../stores'
+
+export const v2PositionIDs = derived(address, async ($address, set) => {
+	if (!CHECK_V2_POSITIONS || !$address) {
+		set([]);
+		return;
+	}
+
+	set(await getV2PositionIDs($address));
+},[]);


### PR DESCRIPTION
Adds a new header link and modal window to notify users when they have active positions against old protocol versions.

Header link is only visible when users have a v1/v2 position open or v1 staked ETH:
![newHeader](https://user-images.githubusercontent.com/93707274/142753459-fde531ba-27c4-4d1f-9fb1-2cf4d40f37d7.png)

Modal window:
![newModal](https://user-images.githubusercontent.com/93707274/142753470-17272e08-2637-4385-adef-f80241499e95.png)

Maybe another word would be better than "Legacy".