### PR TITLE
Show entire amount by default in withdraw dialog

### DIFF
--- a/src/components/Pools.svelte
+++ b/src/components/Pools.svelte
@@ -336,7 +336,7 @@
 						{#if $allowances[_currencyLabel] && $allowances[_currencyLabel]['pool' + _currencyLabel] * 1 == 0}
 							<a on:click={() => {_approveCurrency(_currencyLabel)}}>Approve {formatCurrency(_currencyLabel)}</a>
 						{:else}
-						<a data-intercept="true" class:disabled={!poolInfo.tvl} on:click={() => {showModal('PoolDeposit', {currencyLabel: _currencyLabel})}}>Deposit</a><span class='sep'>|</span><a class:disabled={poolInfo.userBalance == 0} data-intercept="true" on:click={() => {showModal('PoolWithdraw', {currencyLabel: _currencyLabel, withdrawFee: poolInfo.withdrawFee})}}>Withdraw</a>
+						<a data-intercept="true" class:disabled={!poolInfo.tvl} on:click={() => {showModal('PoolDeposit', {currencyLabel: _currencyLabel})}}>Deposit</a><span class='sep'>|</span><a class:disabled={poolInfo.userBalance == 0} data-intercept="true" on:click={() => {showModal('PoolWithdraw', {currencyLabel: _currencyLabel, withdrawFee: poolInfo.withdrawFee, userBalance: poolInfo.userBalance })}}>Withdraw</a>
 						{/if}
 					</div>
 					<div class='value'>{formatToDisplay(poolInfo.userBalance) || 0} {formatCurrency(_currencyLabel)} <span class='grayed'>({formatToDisplay(poolInfo.tvl*1 == 0 ? 0 : 100*poolInfo.userBalance/poolInfo.tvl)}%)</span></div>
@@ -390,7 +390,7 @@
     				{#if $allowances['cap'] && $allowances['cap']['capPool'] * 1 == 0}
     					<a on:click={() => {_approveCurrency('cap')}}>Approve CAP</a>
     				{:else}
-    				<a data-intercept="true" on:click={() => {showModal('PoolDeposit', {currencyLabel: 'cap'})}}>Deposit</a><span class='sep'>|</span><a class:disabled={$capPool.userBalance == 0} data-intercept="true" on:click={() => {showModal('PoolWithdraw', {currencyLabel: 'cap'})}}>Withdraw</a>
+    				<a data-intercept="true" on:click={() => {showModal('PoolDeposit', {currencyLabel: 'cap'})}}>Deposit</a><span class='sep'>|</span><a class:disabled={$capPool.userBalance == 0} data-intercept="true" on:click={() => {showModal('PoolWithdraw', {currencyLabel: 'cap', userBalance: $capPool.userBalance })}}>Withdraw</a>
     				{/if}
     			</div>
     			<div class='value'>

--- a/src/components/modals/PoolWithdraw.svelte
+++ b/src/components/modals/PoolWithdraw.svelte
@@ -39,6 +39,10 @@
 		submitIsPending = false;
 	}
 
+	if (!isNaN(+data.userBalance)) {
+		amount = +data.userBalance;
+	}
+	
 	onMount(async () => {
 
 	});


### PR DESCRIPTION
Sometimes when user removes ETH/USDC from pool, there is always a bit of dust left hopefully this would take care of that.

Another solution is, providing with a slider and users select in % instead of exact amount (The amount can be displayed in a row below and can also be edited)